### PR TITLE
Add enrollment prediction

### DIFF
--- a/app/data/enrollment_data.py
+++ b/app/data/enrollment_data.py
@@ -1,0 +1,90 @@
+year_data = [
+    {
+        "year": 2021,
+        "1stYear":113,
+        "2ndYear":90,
+        "2ndYearTransfer":15,
+        "3rdYear":93,
+        "4thYear":74,
+        "5thYear":44,
+        "6thYear":10,
+        "7thYear":2
+    },
+    {
+        "year": 2020,
+        "1stYear":112,
+        "2ndYear":90,
+        "2ndYearTransfer":14,
+        "3rdYear":92,
+        "4thYear":55,
+        "5thYear":50,
+        "6thYear":8,
+        "7thYear":2
+    },
+    {
+        "year": 2019,
+        "1stYear":124,
+        "2ndYear":99,
+        "2ndYearTransfer":17,
+        "3rdYear":68,
+        "4thYear":63,
+        "5thYear":40,
+        "6thYear":8,
+        "7thYear":1
+    },
+    {
+        "year": 2018,
+        "1stYear":128,
+        "2ndYear":102,
+        "2ndYearTransfer":13,
+        "3rdYear":78,
+        "4thYear":50,
+        "5thYear":39,
+        "6thYear":7,
+        "7thYear":1
+    },
+    {
+        "year": 2017,
+        "1stYear":94,
+        "2ndYear":75,
+        "2ndYearTransfer":10,
+        "3rdYear":63,
+        "4thYear":48,
+        "5thYear":35,
+        "6thYear":7,
+        "7thYear":1
+    },
+    {
+        "year": 2016,
+        "1stYear":111,
+        "2ndYear":89,
+        "2ndYearTransfer":9,
+        "3rdYear":60,
+        "4thYear":44,
+        "5thYear":34,
+        "6thYear":3,
+        "7thYear":1
+    },
+    {
+        "year": 2015,
+        "1stYear":89,
+        "2ndYear":71,
+        "2ndYearTransfer":7,
+        "3rdYear":55,
+        "4thYear":43,
+        "5thYear":17,
+        "6thYear":3,
+        "7thYear":1
+    },
+    {
+        "year": 2014,
+        "1stYear":84,
+        "2ndYear":68,
+        "2ndYearTransfer":8,
+        "3rdYear":54,
+        "4thYear":21,
+        "5thYear":17,
+        "6thYear":4,
+        "7thYear":1
+    }
+]

--- a/app/enrollment_prediction/predict_enrollment.py
+++ b/app/enrollment_prediction/predict_enrollment.py
@@ -1,0 +1,79 @@
+"""Enrollment Predictor
+
+This script takes any number of years as input and outputs a prediction of the number of the number
+of students in each year of the BSEng program based on existing data (2014-2021).
+"""
+import os
+import sys
+import numpy as np
+from argparse import ArgumentParser
+from sklearn.linear_model import LinearRegression
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "../data"))
+from enrollment_data import year_data
+
+ENROLLMENT_DATA = sorted(year_data, key=lambda d: d["year"])
+
+
+def predict_year_size(to_predict: list[int], keys: list[str]) -> np.ndarray:
+    """Returns a prediction for the number of students for a given year and key."""
+    years = list(range(ENROLLMENT_DATA[0]["year"], ENROLLMENT_DATA[-1]["year"] + 1))
+    years = np.array(years).reshape(-1, 1)
+
+    enrollment = []
+
+    for year in ENROLLMENT_DATA:
+        total = 0
+        for key in keys:
+            total += year[key]
+        enrollment.append(total)
+
+    enrollment = np.array(enrollment).reshape(-1, 1)
+
+
+    predict_years = np.array(to_predict).reshape(-1, 1)
+
+    model = LinearRegression()
+    model.fit(years, enrollment)
+
+    return model.predict(predict_years)
+
+
+def predict_all_years(to_predict: list[int]) -> list[dict]:
+    """Returns a list of dictionaries with the predicted enrollment numbers for the provided
+    years."""
+    first_year = predict_year_size(to_predict, ["1stYear"])
+    second_year = predict_year_size(to_predict, ["2ndYear", "2ndYearTransfer"])
+    third_year = predict_year_size(to_predict, ["3rdYear"])
+    fourth_year = predict_year_size(to_predict, ["4thYear"])
+    fifth_year = predict_year_size(to_predict, ["5thYear", "6thYear", "7thYear"])
+
+    output = []
+    for i, year in enumerate(to_predict):
+        entry = {
+            "year": year,
+            "1stYear": int(first_year[i][0]),
+            "2ndYear": int(second_year[i][0]),
+            "3rdYear": int(third_year[i][0]),
+            "4thYear": int(fourth_year[i][0]),
+            "5thYear": int(fifth_year[i][0])
+        }
+        output.append(entry)
+
+    return output
+
+
+def main():
+    """Main function."""
+    parser = ArgumentParser(description="Enrollment Predictor")
+    parser.add_argument("years", type=int, nargs="+", help="years to predict")
+    args = parser.parse_args()
+
+    if not any(vars(args).values()):
+        parser.error("No arguments provided.")
+
+    print(predict_all_years(args.years))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds an enrollment prediction script that takes years as an input and
outputs a list of dictionaries containing the enrollment predictions for
the provided years. The `predict_all_years()` function can be imported
by any other module/script that needs enrollment predictions.