### PR TITLE
feat: inject port for application via env variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,6 @@ WORKDIR /app
 
 COPY ./requirements.txt .
 
-
-
 # RUN apk add --no-cache --update python3 python3-dev gcc gfortran musl-dev g++ libffi-dev openssl-dev libxml2 libxml2-dev libxslt libxslt-dev libjpeg-turbo-dev zlib-dev
 
 RUN pip install --upgrade cython
@@ -14,8 +12,9 @@ RUN pip install -r requirements.txt
 
 COPY . .
 
+ENV PORT=5000
 EXPOSE 5000
 
 ENV FLASK_APP=setup.py
 
-CMD ["flask", "run", "-h", "0.0.0.0", "--port", "5000"]
+CMD ["flask", "run", "-h", "0.0.0.0", "--port", "$PORT"]


### PR DESCRIPTION
This PR modifies the Dockerfile to allow the application port to be set at runtime using environment variables. This is useful for the E2E tests where we might want to map ports outside the application.

Also, apparently macOS uses port 5000 for AirPlay soooo.