### PR TITLE
Repository dispatch event name change to reduce ambiguity w/ C4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,5 +50,5 @@ jobs:
         with:
           token: ${{ secrets.REPO_ACCESS_TOKEN }}
           repository: seng499-s22-company3/shared
-          event-type: algorithm-2
+          event-type: company3-algorithm-2
           client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}", "repo": "algorithm-2"}'


### PR DESCRIPTION
Change event name to reduce ambiguity in E2E tests between company 3 and 4.