### PR TITLE
fix: send dict to flask so it serializes and sets headers correctly

### DIFF
--- a/app/models/model.py
+++ b/app/models/model.py
@@ -25,6 +25,6 @@ def model_predict(data,df):
         if newcapacity_df.at[i,'capacity'] == 0:
             newcapacity_df.at[i,'capacity']=round(result[i])
 
-    return newcapacity_df.to_json(orient="records")
+    return newcapacity_df.to_dict(orient="records")
 
 


### PR DESCRIPTION
Minor change to help with some testing related things. The only difference is that this moves the JSON serialization from Pandas to Flask. This will make Flask set the `Content-Type` header automatically to `application/json`.
```
Connection: keep-alive
Server: gunicorn
Date: Wed, 13 Jul 2022 18:09:33 GMT
Content-Type: text/html; charset=utf-8
Content-Length: 84
Via: 1.1 vegur
```
note the `Content-Type` being text here.