### PR TITLE
Unseen courses and ML capacity logic

### DIFF
--- a/PreProcessing/preprocess.py
+++ b/PreProcessing/preprocess.py
@@ -2,6 +2,8 @@ from argparse import ArgumentParser
 import pandas as pd
 from pathlib import PurePath
 from tqdm import tqdm
+# import json
+# processedData = []
 
 def pre_process() -> pd.DataFrame:
     """Pre-processes raw JSON data for the ML method of Algorithm 2."""
@@ -15,6 +17,8 @@ def pre_process() -> pd.DataFrame:
     df_c = df_c.rename(columns={"enrollment": "capacity"})
     print("Starting Processing ...")
     for i in tqdm(range(len(df_c.index))):
+        # if df_c.at[i, "subjectCourse"] not in processedData:
+        #     processedData.append(df_c.at[i, "subjectCourse"])
         year = int(str(df_c.at[i, "term"])[:-2])
         semester = int(str(df_c.at[i, "term"])[-2:])
 
@@ -103,7 +107,7 @@ def pre_process() -> pd.DataFrame:
         # This is mainly for 2022-2023 classes that dont have this data yet
         if(df_c.at[i, "capacity"] == 0):
             df_c.at[i, "capacity"] = df_c.at[i, "maximumEnrollment"]
-                    
+
     # Remove all sections other than A01
     df_c = df_c[df_c['sequenceNumber'].str.contains('A01')]
 
@@ -118,7 +122,7 @@ def pre_process() -> pd.DataFrame:
 
     # One hot encode 
     df_c = pd.get_dummies(df_c, columns=['subjectCourse','semester'])
-
+    
     return df_c
 
 def main() -> None:
@@ -146,6 +150,9 @@ def main() -> None:
         preprocessed_df.to_json(str(root) + "/app/models/data/training_data.json", orient='records')
     if args.csv:
         preprocessed_df.to_csv(str(root) + "/app/models/data/training_data.csv", index=False)
+
+    # with open('data/ClassData2.json', "w", encoding="utf8") as outfile:
+	#     json.dump(processedData, outfile, indent = 4)
 
 if __name__ == "__main__":
     main()

--- a/app/featureEngineer/featureEngineer.py
+++ b/app/featureEngineer/featureEngineer.py
@@ -9,7 +9,7 @@ def pre_process(data) -> DataFrame:
 
     df = DataFrame(data)
     
-    df = df.assign(**{"# prereqs prev sem":0})
+    df = df.assign(**{"# prereqs prev sem":0,"# Offerings":1})
     df["subjectCourse"] = df["subject"].astype(str)  + df["code"].astype(str)
     df = df.drop(columns = ['subject', 'code'])
 
@@ -24,6 +24,12 @@ def pre_process(data) -> DataFrame:
         df.at[i, "# prereqs"] = len(preReqsList)
         
         for j in df.index:
+            if all([
+                str(df.at[i, "semester"]) == str(df.at[j, "semester"]),
+                df.at[i, "subjectCourse"] == df.at[j, "subjectCourse"]
+            ]):
+                df.at[i, "# Offerings"] = df.at[i, "# Offerings"] + 1
+
             # Number of offerings of the pre reqs in the previous semester
             if (df.at[j, "subjectCourse"] in preReqsList):
                 df.at[i, "# prereqs prev sem"] += 1

--- a/app/featureEngineer/featureEngineer.py
+++ b/app/featureEngineer/featureEngineer.py
@@ -1,6 +1,65 @@
 from pandas import DataFrame, get_dummies,read_json
 import os
 
+course_list=[
+    "CSC111",
+    "CSC115",
+    "CSC225",
+    "CSC226",
+    "CSC230",
+    "CSC320",
+    "CSC360",
+    "CSC361",
+    "CSC370",
+    "ECE300",
+    "ECE310",
+    "ECE320",
+    "ECE330",
+    "ECE340",
+    "ECE360",
+    "ECE455",
+    "ECE458",
+    "ECE488",
+    "SENG265",
+    "SENG275",
+    "SENG310",
+    "SENG321",
+    "SENG371",
+    "SENG401",
+    "SENG468",
+    "SENG474",
+    "CSC355",
+    "ECE216",
+    "ECE241",
+    "ECE250",
+    "ECE255",
+    "ECE260",
+    "ECE350",
+    "ECE355",
+    "ECE356",
+    "ECE365",
+    "ECE370",
+    "ECE380",
+    "ECE399",
+    "ECE403",
+    "ECE463",
+    "SENG350",
+    "SENG360",
+    "ECE220",
+    "ECE242",
+    "ECE299",
+    "ECE410",
+    "ECE499",
+    "SENG426",
+    "SENG440",
+    "SENG499",
+    "CSC460",
+    "SENG411",
+    "SENG421",
+    "SENG435",
+    "SENG466"
+]
+
 def pre_process(data) -> DataFrame:
     """Pre-processes JSON data for the ML model"""
     print("Reading input data")
@@ -16,25 +75,28 @@ def pre_process(data) -> DataFrame:
     df = df.reset_index(drop=True)
 
     for i in df.index:
-         # Get the list of prereqs for this course
-        preReqsIndex = df_p[df_p['course'] == df.at[i, "subjectCourse"]].reset_index()
-        preReqsList = preReqsIndex.at[0, "preReqs"]
+        if df.at[i, "subjectCourse"] not in course_list:
+            df.drop([i])
+        else:
+            # Get the list of prereqs for this course
+            preReqsIndex = df_p[df_p['course'] == df.at[i, "subjectCourse"]].reset_index()
+            preReqsList = preReqsIndex.at[0, "preReqs"]
 
-        # Set the number of pre reqs
-        df.at[i, "# prereqs"] = len(preReqsList)
-        
-        for j in df.index:
-            if all([
-                str(df.at[i, "semester"]) == str(df.at[j, "semester"]),
-                df.at[i, "subjectCourse"] == df.at[j, "subjectCourse"]
-            ]):
-                df.at[i, "# Offerings"] = df.at[i, "# Offerings"] + 1
+            # Set the number of pre reqs
+            df.at[i, "# prereqs"] = len(preReqsList)
+            
+            for j in df.index:
+                if all([
+                    str(df.at[i, "semester"]) == str(df.at[j, "semester"]),
+                    df.at[i, "subjectCourse"] == df.at[j, "subjectCourse"]
+                ]):
+                    df.at[i, "# Offerings"] = df.at[i, "# Offerings"] + 1
 
-            # Number of offerings of the pre reqs in the previous semester
-            if (df.at[j, "subjectCourse"] in preReqsList):
-                df.at[i, "# prereqs prev sem"] += 1
+                # Number of offerings of the pre reqs in the previous semester
+                if (df.at[j, "subjectCourse"] in preReqsList):
+                    df.at[i, "# prereqs prev sem"] += 1
 
-            df.at[i,df.at[j, "subjectCourse"]] = 1
+                df.at[i,df.at[j, "subjectCourse"]] = 1
 
     df = get_dummies(df, columns=['subjectCourse','semester'])
     df.fillna(0, inplace=True, downcast="infer")

--- a/app/models/data/capacity_data.json
+++ b/app/models/data/capacity_data.json
@@ -1,0 +1,402 @@
+[
+    {
+        "subjectCourse": "CSC115",
+        "capacity": 102,
+        "semester": "SUMMER"
+    },
+    {
+        "subjectCourse": "CSC225",
+        "capacity": 60,
+        "semester": "SUMMER"
+    },
+    {
+        "subjectCourse": "CSC226",
+        "capacity": 80,
+        "semester": "SUMMER"
+    },
+    {
+        "subjectCourse": "CSC230",
+        "capacity": 55,
+        "semester": "SUMMER"
+    },
+    {
+        "subjectCourse": "CSC320",
+        "capacity": 124,
+        "semester": "SUMMER"
+    },
+    {
+        "subjectCourse": "CSC360",
+        "capacity": 84,
+        "semester": "SUMMER"
+    },
+    {
+        "subjectCourse": "CSC370",
+        "capacity": 97,
+        "semester": "SUMMER"
+    },
+    {
+        "subjectCourse": "ECE216",
+        "capacity": 122,
+        "semester": "SUMMER"
+    },
+    {
+        "subjectCourse": "ECE220",
+        "capacity": 60,
+        "semester": "SUMMER"
+    },
+    {
+        "subjectCourse": "ECE242",
+        "capacity": 28,
+        "semester": "SUMMER"
+    },
+    {
+        "subjectCourse": "ECE250",
+        "capacity": 15,
+        "semester": "SUMMER"
+    },
+    {
+        "subjectCourse": "ECE260",
+        "capacity": 82,
+        "semester": "SUMMER"
+    },
+    {
+        "subjectCourse": "ECE299",
+        "capacity": 63,
+        "semester": "SUMMER"
+    },
+    {
+        "subjectCourse": "ECE310",
+        "capacity": 28,
+        "semester": "SUMMER"
+    },
+    {
+        "subjectCourse": "ECE403",
+        "capacity": 14,
+        "semester": "SUMMER"
+    },
+    {
+        "subjectCourse": "ECE410",
+        "capacity": 33,
+        "semester": "SUMMER"
+    },
+    {
+        "subjectCourse": "ECE499",
+        "capacity": 62,
+        "semester": "SUMMER"
+    },
+    {
+        "subjectCourse": "SENG265",
+        "capacity": 72,
+        "semester": "SUMMER"
+    },
+    {
+        "subjectCourse": "SENG275",
+        "capacity": 37,
+        "semester": "SUMMER"
+    },
+    {
+        "subjectCourse": "SENG310",
+        "capacity": 121,
+        "semester": "SUMMER"
+    },
+    {
+        "subjectCourse": "SENG426",
+        "capacity": 82,
+        "semester": "SUMMER"
+    },
+    {
+        "subjectCourse": "SENG440",
+        "capacity": 95,
+        "semester": "SUMMER"
+    },
+    {
+        "subjectCourse": "SENG474",
+        "capacity": 55,
+        "semester": "SUMMER"
+    },
+    {
+        "subjectCourse": "SENG499",
+        "capacity": 77,
+        "semester": "SUMMER"
+    },
+    {
+        "subjectCourse": "CSC111",
+        "capacity": 118,
+        "semester": "SPRING"
+    },
+    {
+        "subjectCourse": "CSC115",
+        "capacity": 318,
+        "semester": "SPRING"
+    },
+    {
+        "subjectCourse": "CSC225",
+        "capacity": 109,
+        "semester": "SPRING"
+    },
+    {
+        "subjectCourse": "CSC226",
+        "capacity": 172,
+        "semester": "SPRING"
+    },
+    {
+        "subjectCourse": "CSC230",
+        "capacity": 119,
+        "semester": "SPRING"
+    },
+    {
+        "subjectCourse": "CSC320",
+        "capacity": 177,
+        "semester": "SPRING"
+    },
+    {
+        "subjectCourse": "CSC360",
+        "capacity": 112,
+        "semester": "SPRING"
+    },
+    {
+        "subjectCourse": "CSC361",
+        "capacity": 111,
+        "semester": "SPRING"
+    },
+    {
+        "subjectCourse": "CSC370",
+        "capacity": 145,
+        "semester": "SPRING"
+    },
+    {
+        "subjectCourse": "CSC460",
+        "capacity": 8,
+        "semester": "SPRING"
+    },
+    {
+        "subjectCourse": "ECE300",
+        "capacity": 94,
+        "semester": "SPRING"
+    },
+    {
+        "subjectCourse": "ECE310",
+        "capacity": 123,
+        "semester": "SPRING"
+    },
+    {
+        "subjectCourse": "ECE320",
+        "capacity": 83,
+        "semester": "SPRING"
+    },
+    {
+        "subjectCourse": "ECE330",
+        "capacity": 98,
+        "semester": "SPRING"
+    },
+    {
+        "subjectCourse": "ECE340",
+        "capacity": 94,
+        "semester": "SPRING"
+    },
+    {
+        "subjectCourse": "ECE360",
+        "capacity": 46,
+        "semester": "SPRING"
+    },
+    {
+        "subjectCourse": "ECE455",
+        "capacity": 87,
+        "semester": "SPRING"
+    },
+    {
+        "subjectCourse": "ECE458",
+        "capacity": 95,
+        "semester": "SPRING"
+    },
+    {
+        "subjectCourse": "ECE488",
+        "capacity": 34,
+        "semester": "SPRING"
+    },
+    {
+        "subjectCourse": "SENG265",
+        "capacity": 156,
+        "semester": "SPRING"
+    },
+    {
+        "subjectCourse": "SENG275",
+        "capacity": 72,
+        "semester": "SPRING"
+    },
+    {
+        "subjectCourse": "SENG321",
+        "capacity": 69,
+        "semester": "SPRING"
+    },
+    {
+        "subjectCourse": "SENG371",
+        "capacity": 68,
+        "semester": "SPRING"
+    },
+    {
+        "subjectCourse": "SENG401",
+        "capacity": 72,
+        "semester": "SPRING"
+    },
+    {
+        "subjectCourse": "SENG468",
+        "capacity": 33,
+        "semester": "SPRING"
+    },
+    {
+        "subjectCourse": "SENG474",
+        "capacity": 24,
+        "semester": "SPRING"
+    },
+    {
+        "subjectCourse": "CSC111",
+        "capacity": 331,
+        "semester": "FALL"
+    },
+    {
+        "subjectCourse": "CSC115",
+        "capacity": 136,
+        "semester": "FALL"
+    },
+    {
+        "subjectCourse": "CSC225",
+        "capacity": 156,
+        "semester": "FALL"
+    },
+    {
+        "subjectCourse": "CSC226",
+        "capacity": 103,
+        "semester": "FALL"
+    },
+    {
+        "subjectCourse": "CSC230",
+        "capacity": 138,
+        "semester": "FALL"
+    },
+    {
+        "subjectCourse": "CSC320",
+        "capacity": 97,
+        "semester": "FALL"
+    },
+    {
+        "subjectCourse": "CSC355",
+        "capacity": 102,
+        "semester": "FALL"
+    },
+    {
+        "subjectCourse": "CSC360",
+        "capacity": 122,
+        "semester": "FALL"
+    },
+    {
+        "subjectCourse": "CSC361",
+        "capacity": 68,
+        "semester": "FALL"
+    },
+    {
+        "subjectCourse": "CSC370",
+        "capacity": 133,
+        "semester": "FALL"
+    },
+    {
+        "subjectCourse": "ECE216",
+        "capacity": 54,
+        "semester": "FALL"
+    },
+    {
+        "subjectCourse": "ECE241",
+        "capacity": 59,
+        "semester": "FALL"
+    },
+    {
+        "subjectCourse": "ECE250",
+        "capacity": 167,
+        "semester": "FALL"
+    },
+    {
+        "subjectCourse": "ECE255",
+        "capacity": 107,
+        "semester": "FALL"
+    },
+    {
+        "subjectCourse": "ECE260",
+        "capacity": 98,
+        "semester": "FALL"
+    },
+    {
+        "subjectCourse": "ECE350",
+        "capacity": 78,
+        "semester": "FALL"
+    },
+    {
+        "subjectCourse": "ECE355",
+        "capacity": 130,
+        "semester": "FALL"
+    },
+    {
+        "subjectCourse": "ECE356",
+        "capacity": 15,
+        "semester": "FALL"
+    },
+    {
+        "subjectCourse": "ECE360",
+        "capacity": 106,
+        "semester": "FALL"
+    },
+    {
+        "subjectCourse": "ECE365",
+        "capacity": 146,
+        "semester": "FALL"
+    },
+    {
+        "subjectCourse": "ECE370",
+        "capacity": 78,
+        "semester": "FALL"
+    },
+    {
+        "subjectCourse": "ECE380",
+        "capacity": 73,
+        "semester": "FALL"
+    },
+    {
+        "subjectCourse": "ECE399",
+        "capacity": 70,
+        "semester": "FALL"
+    },
+    {
+        "subjectCourse": "ECE403",
+        "capacity": 10,
+        "semester": "FALL"
+    },
+    {
+        "subjectCourse": "ECE463",
+        "capacity": 48,
+        "semester": "FALL"
+    },
+    {
+        "subjectCourse": "SENG265",
+        "capacity": 232,
+        "semester": "FALL"
+    },
+    {
+        "subjectCourse": "SENG310",
+        "capacity": 108,
+        "semester": "FALL"
+    },
+    {
+        "subjectCourse": "SENG321",
+        "capacity": 72,
+        "semester": "FALL"
+    },
+    {
+        "subjectCourse": "SENG350",
+        "capacity": 91,
+        "semester": "FALL"
+    },
+    {
+        "subjectCourse": "SENG360",
+        "capacity": 111,
+        "semester": "FALL"
+    }
+]

--- a/app/models/model.py
+++ b/app/models/model.py
@@ -2,9 +2,90 @@ from pandas import DataFrame, read_json, read_csv, get_dummies
 from pickle import load
 import json
 
+course_list=[
+    "CSC111",
+    "CSC115",
+    "CSC225",
+    "CSC226",
+    "CSC230",
+    "CSC320",
+    "CSC360",
+    "CSC361",
+    "CSC370",
+    "ECE300",
+    "ECE310",
+    "ECE320",
+    "ECE330",
+    "ECE340",
+    "ECE360",
+    "ECE455",
+    "ECE458",
+    "ECE488",
+    "SENG265",
+    "SENG275",
+    "SENG310",
+    "SENG321",
+    "SENG371",
+    "SENG401",
+    "SENG468",
+    "SENG474",
+    "CSC355",
+    "ECE216",
+    "ECE241",
+    "ECE250",
+    "ECE255",
+    "ECE260",
+    "ECE350",
+    "ECE355",
+    "ECE356",
+    "ECE365",
+    "ECE370",
+    "ECE380",
+    "ECE399",
+    "ECE403",
+    "ECE463",
+    "SENG350",
+    "SENG360",
+    "ECE220",
+    "ECE242",
+    "ECE299",
+    "ECE410",
+    "ECE499",
+    "SENG426",
+    "SENG440",
+    "SENG499",
+    "CSC460",
+    "SENG411",
+    "SENG421",
+    "SENG435",
+    "SENG466"
+]
+
+hardcoded_course_list=[
+    "MATH122",
+    "ENGR002",
+    "MATH109",
+    "MATH100",
+    "MATH110",
+    "ENGR130",
+    "ENGR110",
+    "PHYS110",
+    "MATH101",
+    "ENGR120",
+    "ENGR141",
+    "PHYS111",
+    "ENGR001",
+    "CHEM101",
+    "CHEM150",
+    "STAT260",
+    "ECON180",
+    "ENGR003",
+    "ENGR004"]
+
 def model_predict(data,df):
     """Predict capacity for coures subbmitted using a pretrained ML model"""
     preprocessed_df = read_json('app/models/data/training_data.json')
+    capacity_df = read_json('app/models/data/capacity_data.json')
 
     preprocessed_df = preprocessed_df.loc[[0]]
 
@@ -22,8 +103,32 @@ def model_predict(data,df):
 
     newcapacity_df=DataFrame(data)
     for i in newcapacity_df.index:
-        if newcapacity_df.at[i,'capacity'] == 0:
-            newcapacity_df.at[i,'capacity']=round(result[i])
+        subjectCourse=str(newcapacity_df.at[i,'subject'] + newcapacity_df.at[i,'code'])
+
+        #couse has been seen by ML model
+        if subjectCourse in course_list:
+            if newcapacity_df.at[i,'capacity'] == 0:
+                newcapacity_df.at[i,'capacity']=round(result[i])
+                
+                #check to see if capacity is valid
+                for j in capacity_df.index:
+                    if all([
+                        subjectCourse == capacity_df.at[j, 'subjectCourse'],
+                        newcapacity_df.at[i,'semester'] == capacity_df.at[j, 'semester']
+                    ]):
+                        if newcapacity_df.at[i,'capacity'] < capacity_df.at[j, 'capacity']:
+                            newcapacity_df.at[i,'capacity'] = capacity_df.at[j, 'capacity']
+
+        else:
+            #course is hardcoded into the schedule
+            if subjectCourse in hardcoded_course_list:
+                newcapacity_df.at[i,'capacity'] = 0
+            else:
+                #new course being offered
+                if newcapacity_df.at[i,'capacity'] == 0:
+                    newcapacity_df.at[i,'capacity'] = 80
+
+
 
     return newcapacity_df.to_json(orient="records")
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
 source venv/bin/activate
 export FLASK_APP=setup.py
+export FLASK_DEBUG=1
 flask run -h 0.0.0.0


### PR DESCRIPTION
Added logic to the capacity that is generated by the ML model and courses not seen by the model.

For courses not seen by the model:
- A course that is required for the degree but not seen by the ML model (eg. ECON180) - capacity will be 0
- A new course that is being offered (eg. CSC227) - capacity will be given a default capacity of 80

Capacity logic for ML model:
- If the capacity predicted by ML model is less than the actual capacity of the course in the same semester in the previous year, the predicted capacity will be replaced by that previous actual capacity.

